### PR TITLE
refactor: snapclient service - tunein screen and model

### DIFF
--- a/app/src/main/java/tech/capullo/radio/RadioNavHost.kt
+++ b/app/src/main/java/tech/capullo/radio/RadioNavHost.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
+import tech.capullo.radio.ui.NowPlayingScreen
 import tech.capullo.radio.ui.RadioApp
 import tech.capullo.radio.ui.RadioBroadcasterScreen
 import tech.capullo.radio.ui.RadioTuneInScreen
@@ -14,6 +15,7 @@ import tech.capullo.radio.ui.theme.SchemeChoice
 data object Home
 data object Broadcast
 data object TuneIn
+data object NowPlaying
 
 @Composable
 fun RadioCapulloNavHost() {
@@ -42,7 +44,19 @@ fun RadioCapulloNavHost() {
                     RadioTheme(
                         schemeChoice = SchemeChoice.ORANGE,
                     ) {
-                        RadioTuneInScreen()
+                        RadioTuneInScreen(
+                            onConnected = { serverIp, channel ->
+                                backStack.add(NowPlaying)
+                            },
+                        )
+                    }
+                }
+
+                is NowPlaying -> NavEntry(key) {
+                    RadioTheme(
+                        schemeChoice = SchemeChoice.ORANGE,
+                    ) {
+                        NowPlayingScreen()
                     }
                 }
 

--- a/app/src/main/java/tech/capullo/radio/snapcast/SnapclientProcess.kt
+++ b/app/src/main/java/tech/capullo/radio/snapcast/SnapclientProcess.kt
@@ -72,6 +72,8 @@ class SnapclientProcess @Inject constructor(
         } catch (_: CancellationException) {
             println("Snapclient process cancelled")
             process.destroy()
+            process.waitFor()
+            println("Snapclient process destroyed")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting snapcast process", e)
         }

--- a/app/src/main/java/tech/capullo/radio/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/tech/capullo/radio/ui/NowPlayingScreen.kt
@@ -1,0 +1,192 @@
+package tech.capullo.radio.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import tech.capullo.radio.ui.theme.Typography
+import tech.capullo.radio.viewmodels.RadioTuneInModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NowPlayingScreen(radioTuneInModel: RadioTuneInModel = hiltViewModel()) {
+    val connectionState by radioTuneInModel.connectionState.collectAsState()
+    var showChannelDialog by remember { mutableStateOf(false) }
+    var selectedChannel by remember { mutableStateOf(AudioChannel.STEREO) }
+
+    LaunchedEffect(connectionState.channel) {
+        selectedChannel = connectionState.channel
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { },
+                actions = {
+                    IconButton(onClick = { showChannelDialog = true }) {
+                        Icon(Icons.Filled.Menu, contentDescription = "Menu")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Card(
+                modifier = Modifier
+                    .padding(16.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                shape = MaterialTheme.shapes.medium,
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        text = "Connected to Server",
+                        style = Typography.headlineMedium,
+                    )
+
+                    Text(
+                        text = "Server: ${connectionState.serverIp}",
+                        style = Typography.bodyLarge,
+                    )
+
+                    Text(
+                        text = "Channel: ${connectionState.channel.label}",
+                        style = Typography.bodyLarge,
+                    )
+
+                    Text(
+                        text = "Playing music via Snapclient",
+                        style = Typography.bodyMedium,
+                    )
+
+                    if (connectionState.isConnected) {
+                        Text(
+                            text = "✓ Service is running",
+                            style = Typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    } else {
+                        Text(
+                            text = "⏳ Connecting...",
+                            style = Typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.secondary,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (showChannelDialog) {
+            AudioSettingsDialog(
+                onDismissRequest = { showChannelDialog = false },
+                selectedChannel = selectedChannel,
+                onCheckedChanged = { isChecked, audioChannel ->
+                    if (isChecked && selectedChannel != audioChannel) {
+                        selectedChannel = audioChannel
+                        radioTuneInModel.updateAudioChannel(audioChannel)
+                    }
+                },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun AudioSettingsDialog(
+    onDismissRequest: () -> Unit,
+    selectedChannel: AudioChannel,
+    onCheckedChanged: (Boolean, AudioChannel) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Audio Channel Settings") },
+        text = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(
+                    ButtonGroupDefaults.ConnectedSpaceBetween,
+                ),
+            ) {
+                AudioChannel.entries.forEach { channel ->
+                    ToggleButton(
+                        checked = selectedChannel == channel,
+                        onCheckedChange = { isChecked -> onCheckedChanged(isChecked, channel) },
+                        modifier = Modifier.weight(channel.modifierWeight),
+                        shapes =
+                        when (channel) {
+                            AudioChannel.LEFT -> {
+                                ButtonGroupDefaults.connectedLeadingButtonShapes()
+                            }
+                            AudioChannel.RIGHT -> {
+                                ButtonGroupDefaults.connectedTrailingButtonShapes()
+                            }
+                            AudioChannel.STEREO -> {
+                                ButtonGroupDefaults.connectedMiddleButtonShapes()
+                            }
+                        },
+                        contentPadding = PaddingValues(0.dp),
+                    ) {
+                        Icon(
+                            if (selectedChannel == channel) {
+                                channel.selectedIcon
+                            } else {
+                                channel.unselectedIcon
+                            },
+                            contentDescription = channel.label,
+                        )
+                        Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
+                        Text(
+                            text = channel.label,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Dismiss")
+            }
+        },
+    )
+}

--- a/app/src/main/java/tech/capullo/radio/viewmodels/RadioBroadcasterViewModel.kt
+++ b/app/src/main/java/tech/capullo/radio/viewmodels/RadioBroadcasterViewModel.kt
@@ -178,11 +178,13 @@ class RadioBroadcasterViewModel @Inject constructor(
 
     fun startBroadcasterService() {
         val intent = Intent(applicationContext, RadioBroadcasterService::class.java)
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             applicationContext.startForegroundService(intent)
         } else {
             applicationContext.startService(intent)
         }
+
         applicationContext.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
     }
 

--- a/app/src/main/java/tech/capullo/radio/viewmodels/RadioTuneInModel.kt
+++ b/app/src/main/java/tech/capullo/radio/viewmodels/RadioTuneInModel.kt
@@ -1,21 +1,87 @@
 package tech.capullo.radio.viewmodels
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.content.SharedPreferences
 import android.os.Build
+import android.os.IBinder
 import androidx.core.content.edit
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import tech.capullo.radio.services.SnapclientService
 import tech.capullo.radio.ui.AudioChannel
 import javax.inject.Inject
+
+data class ServiceConnectionState(
+    val isConnected: Boolean = false,
+    val serverIp: String = "",
+    val channel: AudioChannel = AudioChannel.STEREO,
+)
 
 @HiltViewModel
 class RadioTuneInModel @Inject constructor(
     @ApplicationContext private val applicationContext: Context,
 ) : ViewModel() {
+
+    private var binder: SnapclientService.SnapclientBinder? = null
+    private var isBound = false
+
+    private val _connectionState = MutableStateFlow(ServiceConnectionState())
+    val connectionState: StateFlow<ServiceConnectionState> = _connectionState.asStateFlow()
+
+    private val serviceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            binder = service as SnapclientService.SnapclientBinder
+            isBound = true
+
+            // collect both server ip and audio channel settings
+            viewModelScope.launch {
+                launch {
+                    binder?.getSnapserverIpFlow()?.collect { snapserverIp ->
+                        _connectionState.value = connectionState.value.copy(
+                            serverIp = snapserverIp,
+                        )
+                    }
+                }
+                launch {
+                    binder?.getAudioChannelFlow()?.collect { audioChannel ->
+                        _connectionState.value = connectionState.value.copy(
+                            channel = audioChannel,
+                        )
+                    }
+                }
+            }
+
+            _connectionState.value = connectionState.value.copy(
+                isConnected = isBound,
+            )
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            binder = null
+            isBound = false
+
+            _connectionState.value = connectionState.value.copy(
+                isConnected = isBound,
+            )
+        }
+    }
+
+    init {
+        // upon starting, try to bind to the service if it is already running
+        // service connection callback will trigger, changing the UI state
+        Intent(applicationContext, SnapclientService::class.java).also { intent ->
+            applicationContext.bindService(intent, serviceConnection, 0)
+        }
+    }
 
     private fun getSharedPreferences(context: Context): SharedPreferences =
         context.getSharedPreferences("MyApp", Context.MODE_PRIVATE)
@@ -30,6 +96,8 @@ class RadioTuneInModel @Inject constructor(
         getSharedPreferences(applicationContext).getString("my_text", "") ?: ""
 
     fun startSnapclientService(ip: String, audioChannel: AudioChannel) {
+        // UDF -> set the server IP and Audio Channel settings onto the Service, collect the values
+        // as a flow to then display on the UI
         val intent = Intent(applicationContext, SnapclientService::class.java).apply {
             putExtra(SnapclientService.KEY_IP, ip)
             putExtra(SnapclientService.KEY_AUDIO_CHANNEL, audioChannel.ordinal)
@@ -39,6 +107,21 @@ class RadioTuneInModel @Inject constructor(
             applicationContext.startForegroundService(intent)
         } else {
             applicationContext.startService(intent)
+        }
+
+        applicationContext.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
+    }
+
+    fun updateAudioChannel(channel: AudioChannel) {
+        binder?.updateAudioChannel(channel)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        if (isBound) {
+            applicationContext.unbindService(serviceConnection)
+            isBound = false
+            binder = null
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanistPermissions = "0.37.3"
 activityCompose = "1.10.1"
-agp = "8.12.2"
+agp = "8.13.0"
 androidx-junit = "1.3.0"
 composeLatest = "1.7.8"
 composeBom = "2025.08.01"


### PR DESCRIPTION
- Upon entering the tune-in screen, bind to an already running snapclient service if possible
- Snapclient service provides bindings to interface with the underlying snapclient process
- Reactive UI, read status and display info when connection is established
- Real time audio channel selection for running snapclient process