### PR TITLE
refactor: snapclient service - broadcaster screen and model

### DIFF
--- a/app/src/androidTest/java/tech/capullo/radio/RadioBroadcasterEspotiConnectTest.kt
+++ b/app/src/androidTest/java/tech/capullo/radio/RadioBroadcasterEspotiConnectTest.kt
@@ -12,7 +12,8 @@ import androidx.compose.ui.test.printToLog
 import org.junit.Rule
 import org.junit.Test
 import tech.capullo.radio.snapcast.Client
-import tech.capullo.radio.ui.RadioBroadcasterScreenContent
+import tech.capullo.radio.ui.BroadcasterScreenContent
+import tech.capullo.radio.ui.model.AudioChannel
 import tech.capullo.radio.viewmodels.RadioBroadcasterUiState
 
 class RadioBroadcasterEspotiConnectTest {
@@ -29,7 +30,10 @@ class RadioBroadcasterEspotiConnectTest {
 
         // When: RadioBroadcasterScreen is displayed
         composeTestRule.setContent {
-            RadioBroadcasterScreenContent(uiState)
+            BroadcasterScreenContent(
+                uiState,
+                onAudioChannelChange = { },
+            )
         }
         composeTestRule.onRoot().printToLog("TAG")
 
@@ -57,7 +61,10 @@ class RadioBroadcasterEspotiConnectTest {
 
         // When: RadioBroadcasterScreen is displayed
         composeTestRule.setContent {
-            RadioBroadcasterScreenContent(uiState)
+            BroadcasterScreenContent(
+                uiState,
+                onAudioChannelChange = { },
+            )
         }
         composeTestRule.onRoot().printToLog("TAG")
 
@@ -76,11 +83,15 @@ class RadioBroadcasterEspotiConnectTest {
         val uiState = RadioBroadcasterUiState.EspotiPlayerReady(
             hostAddresses = hostAddresses,
             snapcastClients = mockClients,
+            audioChannel = AudioChannel.STEREO,
         )
 
         // When: Composable is displayed
         composeTestRule.setContent {
-            RadioBroadcasterScreenContent(uiState)
+            BroadcasterScreenContent(
+                uiState,
+                onAudioChannelChange = { },
+            )
         }
 
         // Then: Broadcaster host addresses are displayed

--- a/app/src/androidTest/java/tech/capullo/radio/TuneInScreen.kt
+++ b/app/src/androidTest/java/tech/capullo/radio/TuneInScreen.kt
@@ -12,8 +12,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import tech.capullo.radio.ui.AudioChannel
-import tech.capullo.radio.ui.RadioTuneInScreenContent
+import tech.capullo.radio.ui.TuneInScreenContent
+import tech.capullo.radio.ui.model.AudioChannel
 
 @RunWith(AndroidJUnit4::class)
 class TuneInScreen {
@@ -24,13 +24,14 @@ class TuneInScreen {
     @Test
     fun testDefaultChannelSelection() {
         val lastServerText = "192.168.0.1"
-        val isTunedIn = false
         composeTestRule.setContent {
-            RadioTuneInScreenContent(
+            TuneInScreenContent(
                 lastServerText = lastServerText,
-                isTunedIn = isTunedIn,
                 onTextChange = {},
                 onTuneInClick = {},
+                isButtonEnabled = true,
+                selectedChannel = AudioChannel.STEREO,
+                onChannelChange = {},
             )
         }
 
@@ -51,13 +52,14 @@ class TuneInScreen {
     @Test
     fun testSameChannelSelection() {
         val lastServerText = "192.168.0.1"
-        val isTunedIn = false
         composeTestRule.setContent {
-            RadioTuneInScreenContent(
+            TuneInScreenContent(
                 lastServerText = lastServerText,
-                isTunedIn = isTunedIn,
                 onTextChange = {},
                 onTuneInClick = {},
+                isButtonEnabled = false,
+                selectedChannel = AudioChannel.STEREO,
+                onChannelChange = { },
             )
         }
 
@@ -82,15 +84,16 @@ class TuneInScreen {
     @Test
     fun testChannelSelectionRestoration() {
         val lastServerText = "192.168.0.1"
-        val isTunedIn = false
 
         val restorationTester = StateRestorationTester(composeTestRule)
         restorationTester.setContent {
-            RadioTuneInScreenContent(
+            TuneInScreenContent(
                 lastServerText = lastServerText,
-                isTunedIn = isTunedIn,
                 onTextChange = {},
                 onTuneInClick = {},
+                isButtonEnabled = false,
+                selectedChannel = AudioChannel.RIGHT,
+                onChannelChange = { },
             )
         }
 

--- a/app/src/main/java/tech/capullo/radio/RadioNavHost.kt
+++ b/app/src/main/java/tech/capullo/radio/RadioNavHost.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
+import tech.capullo.radio.ui.BroadcasterScreen
 import tech.capullo.radio.ui.NowPlayingScreen
-import tech.capullo.radio.ui.RadioApp
-import tech.capullo.radio.ui.RadioBroadcasterScreen
-import tech.capullo.radio.ui.RadioTuneInScreen
+import tech.capullo.radio.ui.RadioHomeScreen
+import tech.capullo.radio.ui.TuneInScreen
 import tech.capullo.radio.ui.theme.RadioTheme
 import tech.capullo.radio.ui.theme.SchemeChoice
 
@@ -26,7 +26,7 @@ fun RadioCapulloNavHost() {
         entryProvider = { key ->
             when (key) {
                 is Home -> NavEntry(key) {
-                    RadioApp(
+                    RadioHomeScreen(
                         onStartBroadcastingClicked = { backStack.add(Broadcast) },
                         onTuneInClicked = { backStack.add(TuneIn) },
                     )
@@ -36,7 +36,7 @@ fun RadioCapulloNavHost() {
                     RadioTheme(
                         schemeChoice = SchemeChoice.GREEN,
                     ) {
-                        RadioBroadcasterScreen()
+                        BroadcasterScreen()
                     }
                 }
 
@@ -44,10 +44,8 @@ fun RadioCapulloNavHost() {
                     RadioTheme(
                         schemeChoice = SchemeChoice.ORANGE,
                     ) {
-                        RadioTuneInScreen(
-                            onConnected = { serverIp, channel ->
-                                backStack.add(NowPlaying)
-                            },
+                        TuneInScreen(
+                            onConnected = { backStack.add(NowPlaying) },
                         )
                     }
                 }

--- a/app/src/main/java/tech/capullo/radio/services/SnapclientService.kt
+++ b/app/src/main/java/tech/capullo/radio/services/SnapclientService.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import tech.capullo.radio.snapcast.SnapclientProcess
-import tech.capullo.radio.ui.AudioChannel
+import tech.capullo.radio.ui.model.AudioChannel
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app/src/main/java/tech/capullo/radio/snapcast/SnapclientProcess.kt
+++ b/app/src/main/java/tech/capullo/radio/snapcast/SnapclientProcess.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import tech.capullo.radio.data.RadioRepository
-import tech.capullo.radio.ui.AudioChannel
+import tech.capullo.radio.ui.model.AudioChannel
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.util.UUID

--- a/app/src/main/java/tech/capullo/radio/ui/AudioSettingsDialog.kt
+++ b/app/src/main/java/tech/capullo/radio/ui/AudioSettingsDialog.kt
@@ -1,0 +1,80 @@
+package tech.capullo.radio.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import tech.capullo.radio.ui.model.AudioChannel
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun AudioSettingsDialog(
+    onDismissRequest: () -> Unit,
+    selectedChannel: AudioChannel,
+    onCheckedChanged: (Boolean, AudioChannel) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Audio Channel Settings") },
+        text = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(
+                    ButtonGroupDefaults.ConnectedSpaceBetween,
+                ),
+            ) {
+                AudioChannel.entries.forEach { channel ->
+                    ToggleButton(
+                        checked = selectedChannel == channel,
+                        onCheckedChange = { isChecked -> onCheckedChanged(isChecked, channel) },
+                        modifier = Modifier.Companion.weight(channel.modifierWeight),
+                        shapes =
+                        when (channel) {
+                            AudioChannel.LEFT -> {
+                                ButtonGroupDefaults.connectedLeadingButtonShapes()
+                            }
+
+                            AudioChannel.RIGHT -> {
+                                ButtonGroupDefaults.connectedTrailingButtonShapes()
+                            }
+
+                            AudioChannel.STEREO -> {
+                                ButtonGroupDefaults.connectedMiddleButtonShapes()
+                            }
+                        },
+                        contentPadding = PaddingValues(0.dp),
+                    ) {
+                        Icon(
+                            if (selectedChannel == channel) {
+                                channel.selectedIcon
+                            } else {
+                                channel.unselectedIcon
+                            },
+                            contentDescription = channel.label,
+                        )
+                        Spacer(Modifier.Companion.size(ToggleButtonDefaults.IconSpacing))
+                        Text(
+                            text = channel.label,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Dismiss")
+            }
+        },
+    )
+}

--- a/app/src/main/java/tech/capullo/radio/ui/NowPlayingScreen.kt
+++ b/app/src/main/java/tech/capullo/radio/ui/NowPlayingScreen.kt
@@ -2,28 +2,18 @@ package tech.capullo.radio.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.ToggleButton
-import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import tech.capullo.radio.ui.model.AudioChannel
 import tech.capullo.radio.ui.theme.Typography
 import tech.capullo.radio.viewmodels.RadioTuneInModel
 
@@ -121,7 +112,7 @@ fun NowPlayingScreen(radioTuneInModel: RadioTuneInModel = hiltViewModel()) {
             AudioSettingsDialog(
                 onDismissRequest = { showChannelDialog = false },
                 selectedChannel = selectedChannel,
-                onCheckedChanged = { isChecked, audioChannel ->
+                onCheckedChanged = { isChecked: Boolean, audioChannel: AudioChannel ->
                     if (isChecked && selectedChannel != audioChannel) {
                         selectedChannel = audioChannel
                         radioTuneInModel.updateAudioChannel(audioChannel)
@@ -130,63 +121,4 @@ fun NowPlayingScreen(radioTuneInModel: RadioTuneInModel = hiltViewModel()) {
             )
         }
     }
-}
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-fun AudioSettingsDialog(
-    onDismissRequest: () -> Unit,
-    selectedChannel: AudioChannel,
-    onCheckedChanged: (Boolean, AudioChannel) -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = { Text("Audio Channel Settings") },
-        text = {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(
-                    ButtonGroupDefaults.ConnectedSpaceBetween,
-                ),
-            ) {
-                AudioChannel.entries.forEach { channel ->
-                    ToggleButton(
-                        checked = selectedChannel == channel,
-                        onCheckedChange = { isChecked -> onCheckedChanged(isChecked, channel) },
-                        modifier = Modifier.weight(channel.modifierWeight),
-                        shapes =
-                        when (channel) {
-                            AudioChannel.LEFT -> {
-                                ButtonGroupDefaults.connectedLeadingButtonShapes()
-                            }
-                            AudioChannel.RIGHT -> {
-                                ButtonGroupDefaults.connectedTrailingButtonShapes()
-                            }
-                            AudioChannel.STEREO -> {
-                                ButtonGroupDefaults.connectedMiddleButtonShapes()
-                            }
-                        },
-                        contentPadding = PaddingValues(0.dp),
-                    ) {
-                        Icon(
-                            if (selectedChannel == channel) {
-                                channel.selectedIcon
-                            } else {
-                                channel.unselectedIcon
-                            },
-                            contentDescription = channel.label,
-                        )
-                        Spacer(Modifier.size(ToggleButtonDefaults.IconSpacing))
-                        Text(
-                            text = channel.label,
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text("Dismiss")
-            }
-        },
-    )
 }

--- a/app/src/main/java/tech/capullo/radio/ui/RadioHomeScreen.kt
+++ b/app/src/main/java/tech/capullo/radio/ui/RadioHomeScreen.kt
@@ -45,7 +45,7 @@ import tech.capullo.radio.ui.theme.SchemeChoice
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun RadioApp(onStartBroadcastingClicked: () -> Unit, onTuneInClicked: () -> Unit) {
+fun RadioHomeScreen(onStartBroadcastingClicked: () -> Unit, onTuneInClicked: () -> Unit) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         val multiplePermissionsState =
             rememberMultiplePermissionsState(
@@ -55,7 +55,7 @@ fun RadioApp(onStartBroadcastingClicked: () -> Unit, onTuneInClicked: () -> Unit
                 ),
             )
         if (multiplePermissionsState.allPermissionsGranted) {
-            RadioMainScreen(
+            RadioHomeScreenContent(
                 onStartBroadcastingClicked = onStartBroadcastingClicked,
                 onTuneInClicked = onTuneInClicked,
             )
@@ -67,7 +67,7 @@ fun RadioApp(onStartBroadcastingClicked: () -> Unit, onTuneInClicked: () -> Unit
         }
     } else {
         // For devices below TIRAMISU, show the main screen directly
-        RadioMainScreen(
+        RadioHomeScreenContent(
             onStartBroadcastingClicked = onStartBroadcastingClicked,
             onTuneInClicked = onTuneInClicked,
         )
@@ -76,7 +76,7 @@ fun RadioApp(onStartBroadcastingClicked: () -> Unit, onTuneInClicked: () -> Unit
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun RadioMainScreen(onStartBroadcastingClicked: () -> Unit, onTuneInClicked: () -> Unit) {
+fun RadioHomeScreenContent(onStartBroadcastingClicked: () -> Unit, onTuneInClicked: () -> Unit) {
     Scaffold { innerPadding ->
         Column(
             modifier = Modifier
@@ -215,9 +215,9 @@ fun HelpTooltip() {
     showSystemUi = true,
 )
 @Composable
-fun RadioAppPreview() {
+fun RadioHomeScreenPreview() {
     RadioTheme {
-        RadioMainScreen(
+        RadioHomeScreenContent(
             onStartBroadcastingClicked = {},
             onTuneInClicked = {},
         )

--- a/app/src/main/java/tech/capullo/radio/ui/TuneInScreen.kt
+++ b/app/src/main/java/tech/capullo/radio/ui/TuneInScreen.kt
@@ -13,13 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Notifications
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material.icons.outlined.Notifications
-import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonGroupDefaults
@@ -44,21 +37,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import tech.capullo.radio.ui.model.AudioChannel
 import tech.capullo.radio.ui.theme.RadioTheme
 import tech.capullo.radio.ui.theme.SchemeChoice
 import tech.capullo.radio.ui.theme.Typography
 import tech.capullo.radio.viewmodels.RadioTuneInModel
 
 @Composable
-fun RadioTuneInScreen(
-    radioTuneInModel: RadioTuneInModel = hiltViewModel(),
-    onConnected: (serverIp: String, channel: AudioChannel) -> Unit = { _, _ -> },
-) {
+fun TuneInScreen(radioTuneInModel: RadioTuneInModel = hiltViewModel(), onConnected: () -> Unit) {
     var lastServerText by remember {
         mutableStateOf(radioTuneInModel.getLastServerText())
     }
@@ -71,11 +61,11 @@ fun RadioTuneInScreen(
     if (connectionState.isConnected &&
         connectionState.serverIp.isNotEmpty()
     ) {
-        onConnected(connectionState.serverIp, connectionState.channel)
+        onConnected()
     }
 
     Scaffold { innerPadding ->
-        RadioTuneInScreenContent(
+        TuneInScreenContent(
             modifier = Modifier
                 .padding(innerPadding),
             lastServerText = lastServerText,
@@ -96,35 +86,9 @@ fun RadioTuneInScreen(
     }
 }
 
-enum class AudioChannel(
-    val selectedIcon: ImageVector,
-    val unselectedIcon: ImageVector,
-    val modifierWeight: Float,
-    val label: String,
-) {
-    LEFT(
-        selectedIcon = Icons.Filled.MoreVert,
-        unselectedIcon = Icons.Outlined.MoreVert,
-        modifierWeight = 1f,
-        "Left",
-    ),
-    STEREO(
-        selectedIcon = Icons.Filled.Notifications,
-        unselectedIcon = Icons.Outlined.Notifications,
-        modifierWeight = 1.5f,
-        "Stereo",
-    ),
-    RIGHT(
-        selectedIcon = Icons.Filled.PlayArrow,
-        unselectedIcon = Icons.Outlined.PlayArrow,
-        modifierWeight = 1f,
-        "Right",
-    ),
-}
-
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun RadioTuneInScreenContent(
+fun TuneInScreenContent(
     modifier: Modifier = Modifier,
     lastServerText: String,
     isButtonEnabled: Boolean,
@@ -256,7 +220,7 @@ fun PreviewRadioTuneInContent() {
     val selectedChannel = AudioChannel.STEREO
 
     RadioTheme(schemeChoice = SchemeChoice.ORANGE) {
-        RadioTuneInScreenContent(
+        TuneInScreenContent(
             lastServerText = lastServerText,
             isButtonEnabled = isButtonEnabled,
             selectedChannel = selectedChannel,

--- a/app/src/main/java/tech/capullo/radio/ui/model/AudioChannel.kt
+++ b/app/src/main/java/tech/capullo/radio/ui/model/AudioChannel.kt
@@ -1,0 +1,36 @@
+package tech.capullo.radio.ui.model
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class AudioChannel(
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector,
+    val modifierWeight: Float,
+    val label: String,
+) {
+    LEFT(
+        selectedIcon = Icons.Filled.MoreVert,
+        unselectedIcon = Icons.Outlined.MoreVert,
+        modifierWeight = 1f,
+        "Left",
+    ),
+    STEREO(
+        selectedIcon = Icons.Filled.Notifications,
+        unselectedIcon = Icons.Outlined.Notifications,
+        modifierWeight = 1.5f,
+        "Stereo",
+    ),
+    RIGHT(
+        selectedIcon = Icons.Filled.PlayArrow,
+        unselectedIcon = Icons.Outlined.PlayArrow,
+        modifierWeight = 1f,
+        "Right",
+    ),
+}

--- a/app/src/main/java/tech/capullo/radio/viewmodels/TuneInViewModel.kt
+++ b/app/src/main/java/tech/capullo/radio/viewmodels/TuneInViewModel.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import tech.capullo.radio.services.SnapclientService
-import tech.capullo.radio.ui.AudioChannel
+import tech.capullo.radio.ui.model.AudioChannel
 import javax.inject.Inject
 
 data class ServiceConnectionState(


### PR DESCRIPTION
- AudioSettingsDialog as a standalone composable
- snapserver and snapclient process change from deferred to Job on broadcaster service
- Restart mechanism for snapclient from BroadcasterService when selecting a new channel