### PR TITLE
snapserver nsd advertisement with device name

### DIFF
--- a/app/src/androidTest/java/tech/capullo/radio/SnapserverDiscoveryTest.kt
+++ b/app/src/androidTest/java/tech/capullo/radio/SnapserverDiscoveryTest.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
+import tech.capullo.radio.data.PipeFileDataSource
+import tech.capullo.radio.data.RadioAdvertisingDataSource
+import tech.capullo.radio.data.RadioRepository
 import tech.capullo.radio.snapcast.SnapserverDiscoveryManager
 import tech.capullo.radio.snapcast.SnapserverNsdManager
 
@@ -18,16 +21,20 @@ class SnapserverDiscoveryTest {
     @Test
     fun testDiscoversSnapserverServices() = runBlocking {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val pipeFileDataSource = PipeFileDataSource(appContext)
+        val radioAdvertisingDataSource = RadioAdvertisingDataSource(appContext)
+        val repository = RadioRepository(pipeFileDataSource, radioAdvertisingDataSource)
         val nsdManager = appContext.getSystemService(Context.NSD_SERVICE) as NsdManager
 
         launch {
-            SnapserverNsdManager(nsdManager).start()
+            SnapserverNsdManager(nsdManager, repository).start()
         }
 
         val snapserverDiscoveryManager = SnapserverDiscoveryManager(nsdManager)
         snapserverDiscoveryManager.startDiscovery()
 
         delay(5000)
+        println(snapserverDiscoveryManager.discoveredServices.value)
         assert(snapserverDiscoveryManager.discoveredServices.value.isNotEmpty())
     }
 }

--- a/app/src/main/java/tech/capullo/radio/snapcast/SnapserverDiscoveryManager.kt
+++ b/app/src/main/java/tech/capullo/radio/snapcast/SnapserverDiscoveryManager.kt
@@ -161,10 +161,29 @@ class SnapserverDiscoveryManager @Inject constructor(private val nsdManager: Nsd
                 _discoveredServices.value =
                     availableServers.filter { it.value.first != null || it.value.second != null }
                         .map {
+                            // TODO: display both stream and control ports
                             val serviceInfo = when {
                                 it.value.first != null -> it.value.first!!
                                 else -> it.value.second!!
                             }
+
+                            // for backwards compatibility with badaix/snapdroid, it will discover
+                            // _snapcast._tcp services only if the service name begins with "Snapcast"
+                            // reference: https://github.com/badaix/snapdroid/blob/0c707f930c422699789d38156eb896edd37dc02a/Snapcast/src/main/java/de/badaix/snapcast/utils/NsdHelper.java#L141
+
+                            // RadioCapullo advertises as: "Snapcast - ${deviceName}"
+                            // Strip out the "Snapcast - " suffix and only display the device name
+                            serviceInfo.serviceName =
+                                if (serviceInfo.serviceName.startsWith(
+                                        SnapserverNsdManager.SERVICE_NAME_PREFIX,
+                                    )
+                                ) {
+                                    serviceInfo.serviceName.substring(
+                                        SnapserverNsdManager.SERVICE_NAME_PREFIX.length,
+                                    )
+                                } else {
+                                    serviceInfo.serviceName
+                                }
                             DiscoveredSnapserver(
                                 serviceName = serviceInfo.serviceName,
                                 serviceType = serviceInfo.serviceType,

--- a/app/src/main/java/tech/capullo/radio/snapcast/SnapserverNsdManager.kt
+++ b/app/src/main/java/tech/capullo/radio/snapcast/SnapserverNsdManager.kt
@@ -3,21 +3,25 @@ package tech.capullo.radio.snapcast
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.util.Log
+import tech.capullo.radio.data.RadioRepository
 import javax.inject.Inject
 
-class SnapserverNsdManager @Inject constructor(private val nsdManager: NsdManager) {
+class SnapserverNsdManager @Inject constructor(
+    private val nsdManager: NsdManager,
+    private val repository: RadioRepository,
+) {
 
     private val registeredListeners = mutableListOf<NsdManager.RegistrationListener>()
 
     fun start() {
         val controlServiceInfo = NsdServiceInfo().apply {
-            serviceName = SERVICE_NAME
+            serviceName = SERVICE_NAME_PREFIX + repository.getDeviceName()
             serviceType = SERVICE_TYPE
             port = SERVICE_PORT
         }
 
         val streamServiceInfo = NsdServiceInfo().apply {
-            serviceName = SERVICE_NAME
+            serviceName = SERVICE_NAME_PREFIX + repository.getDeviceName()
             serviceType = STREAM_SERVICE_TYPE
             port = STREAM_SERVICE_PORT
         }
@@ -67,7 +71,7 @@ class SnapserverNsdManager @Inject constructor(private val nsdManager: NsdManage
 
     companion object {
         private val TAG = SnapserverNsdManager::class.java.simpleName
-        const val SERVICE_NAME = "Snapcast"
+        const val SERVICE_NAME_PREFIX = "Snapcast - "
         const val SERVICE_TYPE = "_snapcast._tcp"
         const val SERVICE_PORT = 1704
         const val STREAM_SERVICE_TYPE = "_snapcast-stream._tcp"

--- a/app/src/main/java/tech/capullo/radio/ui/TuneInScreen.kt
+++ b/app/src/main/java/tech/capullo/radio/ui/TuneInScreen.kt
@@ -197,13 +197,20 @@ fun ServerListItem(server: DiscoveredSnapserver, isSelected: Boolean, onClick: (
                 .padding(horizontal = 16.dp, vertical = 24.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = server.hostAddress,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            Column {
+                Text(
+                    text = server.serviceName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Text(
+                    text = server.hostAddress,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
 
             Spacer(Modifier.weight(1f))
 
@@ -242,16 +249,16 @@ fun ServerListItem(server: DiscoveredSnapserver, isSelected: Boolean, onClick: (
 @Composable
 fun PreviewRadioTuneInContent() {
     val discoveredServices = listOf(
-        DiscoveredSnapserver("Snapcast Server 1", "_snapcast._tcp", "192.168.1.100", 1704),
-        DiscoveredSnapserver("Snapcast Server 2", "_snapcast._tcp", "192.168.1.101", 1704),
-        DiscoveredSnapserver("Snapcast Server 3", "_snapcast._tcp", "192.168.1.102", 1704),
-        DiscoveredSnapserver("Snapcast Server 4", "_snapcast._tcp", "192.168.1.103", 1704),
-        DiscoveredSnapserver("Snapcast Server 5", "_snapcast._tcp", "192.168.1.104", 1704),
-        DiscoveredSnapserver("Snapcast Server 6", "_snapcast._tcp", "192.168.1.105", 1704),
-        DiscoveredSnapserver("Snapcast Server 7", "_snapcast._tcp", "192.168.1.106", 1704),
-        DiscoveredSnapserver("Snapcast Server 8", "_snapcast._tcp", "192.168.1.107", 1704),
-        DiscoveredSnapserver("Snapcast Server 9", "_snapcast._tcp", "192.168.1.108", 1704),
-        DiscoveredSnapserver("Snapcast Server 10", "_snapcast._tcp", "192.168.1.109", 1704),
+        DiscoveredSnapserver("Pixel 3a", "_snapcast._tcp", "192.168.1.100", 1704),
+        DiscoveredSnapserver("OnePlus 3T", "_snapcast._tcp", "192.168.1.101", 1704),
+        DiscoveredSnapserver("Nacatambucho de Karin", "_snapcast._tcp", "192.168.1.102", 1704),
+        DiscoveredSnapserver("Snapcast", "_snapcast._tcp", "192.168.1.103", 1704),
+        DiscoveredSnapserver("Snapcast", "_snapcast._tcp", "192.168.1.104", 1704),
+        DiscoveredSnapserver("Snapcast", "_snapcast._tcp", "192.168.1.105", 1704),
+        DiscoveredSnapserver("Snapcast", "_snapcast._tcp", "192.168.1.106", 1704),
+        DiscoveredSnapserver("Snapcast", "_snapcast._tcp", "192.168.1.107", 1704),
+        DiscoveredSnapserver("Snapcast", "_snapcast._tcp", "192.168.1.108", 1704),
+        DiscoveredSnapserver("Snapcast", "_snapcast._tcp", "192.168.1.109", 1704),
     )
 
     val uiState = TuneInState(


### PR DESCRIPTION
- Use device name in the NSD advertised service
- Strip out the "Snapcast - " prefix to maintain backwards compatibility with badaix/snapdroid. Ref: https://github.com/badaix/snapdroid/blob/0c707f930c422699789d38156eb896edd37dc02a/Snapcast/src/main/java/de/badaix/snapcast/utils/NsdHelper.java#L141