### PR TITLE
feat: sl4j android logger implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     packaging {
         resources {
@@ -56,6 +57,12 @@ android {
             jniLibs {
                 useLegacyPackaging = true
             }
+        }
+    }
+    testOptions {
+        unitTests {
+            isReturnDefaultValues = true
+            // TODO: introduce robolectric
         }
     }
 }
@@ -97,6 +104,7 @@ dependencies {
         exclude(group = "com.lmax", module = "disruptor")
         exclude(group = "org.apache.logging.log4j")
     }
+    implementation(libs.slf4j.handroid)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,7 +56,7 @@
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="merge">
-            <meta-data  android:name="tech.capullo.radio.espoti.AndroidNativeDecoderInitializer"
+            <meta-data  android:name="tech.capullo.radio.espoti.EspotiInitializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/app/src/main/java/tech/capullo/radio/espoti/EspotiInitializer.kt
+++ b/app/src/main/java/tech/capullo/radio/espoti/EspotiInitializer.kt
@@ -1,16 +1,23 @@
 package tech.capullo.radio.espoti
 
 import android.content.Context
+import android.os.Build
 import androidx.startup.Initializer
+import org.slf4j.impl.HandroidLoggerAdapter
+import tech.capullo.radio.BuildConfig
 import xyz.gianlu.librespot.audio.decoders.Decoders
 import xyz.gianlu.librespot.audio.format.SuperAudioFormat
 
-class AndroidNativeDecoderInitializer : Initializer<Unit> {
+class EspotiInitializer : Initializer<Unit> {
 
     override fun create(context: Context) {
         // This initializer doesn't return anything (Unit)
         Decoders.registerDecoder(SuperAudioFormat.VORBIS, 0, AndroidNativeDecoder::class.java)
         Decoders.registerDecoder(SuperAudioFormat.MP3, 0, AndroidNativeDecoder::class.java)
+
+        HandroidLoggerAdapter.DEBUG = BuildConfig.DEBUG
+        HandroidLoggerAdapter.ANDROID_API_LEVEL = Build.VERSION.SDK_INT
+        HandroidLoggerAdapter.APP_NAME = "tech.capullo.radio"
     }
 
     override fun dependencies(): List<Class<out Initializer<*>>> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ material3 = "1.5.0-alpha07"
 media = "1.7.1"
 mockk = "1.14.6"
 navigation3 = "1.0.0-beta01"
+slf4jHandroid = "2.0.13"
 startupRuntime = "1.2.0"
 spotless = "8.0.0"
 
@@ -62,6 +63,7 @@ ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" 
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 lib-snapcast-android = { group = "com.github.capullo-tech.lib-snapcast-android", name = "lib-snapcast-android", version.ref = "libSnapcastAndroid" }
 mockk = { group= "io.mockk", name = "mockk", version.ref = "mockk" }
+slf4j-handroid = { module = "com.gitlab.mvysny.slf4j:slf4j-handroid", version.ref = "slf4jHandroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
### Context: 
librespot has a sl4j logger dependency that the project is not providing an implementation for:

<img width="1452" height="80" alt="Screenshot_20251029_153158" src="https://github.com/user-attachments/assets/1d94dd3b-5b7a-4ef6-9164-39d2d3137ad2" />


Causing potential log messages from librespot to be skipped during development.

In this PR we introduce the sl4j android logger implementation via: [com.gitlab.mvysny.slf4j:slf4j-handroid](https://gitlab.com/mvysny/slf4j-handroid)

### Example
logging:

<img width="957" height="153" alt="Screenshot_20251029_154026" src="https://github.com/user-attachments/assets/93748d5a-2878-42b9-a135-4a9c8beaf26e" />

which comes from the upstream librespot project: https://github.com/librespot-org/librespot-java/blob/90978c1ce60b40344e3a6f70dae560b9c9a8a818/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueueEntry.java#L125
```java
LOGGER.info("Loaded track. {name: '{}', artists: '{}', duration: {}, uri: {}, id: {}}", metadata.track.getName(),
```

