### PR TITLE
feat: snapcast control JSON RPC

### DIFF
--- a/app/src/androidTest/java/tech/capullo/radio/SnapcastControlClientInstrumentedTest.kt
+++ b/app/src/androidTest/java/tech/capullo/radio/SnapcastControlClientInstrumentedTest.kt
@@ -3,18 +3,27 @@ package tech.capullo.radio
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
-import org.junit.Assert.assertNotNull
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import tech.capullo.radio.data.ConfFileDataSource
 import tech.capullo.radio.data.RadioAdvertisingDataSource
 import tech.capullo.radio.data.RadioRepository
+import tech.capullo.radio.snapcast.ServerGetStatusResponse
+import tech.capullo.radio.snapcast.ServerOnUpdate
 import tech.capullo.radio.snapcast.SnapcastControlClient
 import tech.capullo.radio.snapcast.SnapclientProcess
 import tech.capullo.radio.snapcast.SnapserverProcess
@@ -34,63 +43,84 @@ class SnapcastControlClientInstrumentedTest {
     }
 
     @Test
-    fun testSnapcastControlClientConnection() = runBlocking {
-        // Start a snapserver process
-        val serverJob = launch(Dispatchers.IO) {
-            val snapserverProcess = SnapserverProcess(radioRepository)
-            snapserverProcess.start()
+    fun serverGetStatusAfterOneClientConnection() = runTest {
+        // Setup
+        backgroundScope.launch(Dispatchers.IO) {
+            SnapserverProcess(radioRepository).start()
         }
 
-        // Give server time to start
-        delay(2000)
+        val snapcastControlClient = SnapcastControlClient(
+            "127.0.0.1",
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+        snapcastControlClient.initialize()
 
-        // Start a snapclient process
-        val snapclientJob = launch(Dispatchers.IO) {
-            val snapclientProcess = SnapclientProcess(appContext, radioRepository)
-            snapclientProcess.start()
+        // no client connections yet, querying for the status should return us an empty list
+        snapcastControlClient.sendGetStatus()
+
+        var notification = snapcastControlClient.notifications.first()
+
+        assert(notification is ServerGetStatusResponse)
+        (notification as ServerGetStatusResponse).also { serverGetStatusResponse ->
+            assert(serverGetStatusResponse.result.server.groups.isEmpty())
         }
 
-        // Give client time to connect
-        delay(2000)
-
-        // Create and test the control client
-        val snapcastControlClient = SnapcastControlClient("127.0.0.1")
-
-        // Start listening for server status updates
-        val statusJob = launch {
-            println("Listening for server status updates")
-            val result = withTimeoutOrNull(5000) {
-                snapcastControlClient.serverStatus.first()
-            }
-            println("Received server status: $result")
-            assertNotNull("Should receive server status", result)
-
-            println("Checking server status")
-            result?.let {
-                // Verify some basic structure of the response
-                assertNotNull(it.result)
-                assertNotNull(it.result.server)
-                assertNotNull(it.result.server.groups)
-                // assertTrue("Server should have a version", it.result.server.version.isNotEmpty())
-            }
-            println("Server status check complete")
+        // expecting a serverOnUpdate right after a snapclient has connected
+        backgroundScope.launch(Dispatchers.IO) {
+            SnapclientProcess(appContext, radioRepository).start()
         }
 
-        // Initialize the websocket connection
-        val controlClientJob = launch(Dispatchers.IO) {
-            snapcastControlClient.initWebsocket()
+        notification = snapcastControlClient.notifications.first()
+
+        assert(notification is ServerOnUpdate)
+        (notification as ServerOnUpdate).also { serverOnUpdate ->
+            assert(serverOnUpdate.params.server.groups.size == 1)
         }
 
-        // Wait for status job to complete
-        println("Waiting for status job to complete")
-        statusJob.join()
-        println("Status job complete")
+        // querying again for the server.getStatus should be consistent
+        snapcastControlClient.sendGetStatus()
+        notification = snapcastControlClient.notifications.first()
 
-        // Clean up
-        println("Cleaning up")
-        snapclientJob.cancel()
-        serverJob.cancel()
-        controlClientJob.cancel()
-        println("Cleanup complete")
+        assert(notification is ServerGetStatusResponse)
+        (notification as ServerGetStatusResponse).also { serverGetStatusResponse ->
+            assert(serverGetStatusResponse.result.server.groups.size == 1)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun notificationCollectionDuringSnapserverShutdown() = runTest {
+        // Setup
+        val serverJob = backgroundScope.launch(Dispatchers.IO) {
+            SnapserverProcess(radioRepository).start()
+        }
+
+        val snapcastControlClient = SnapcastControlClient(
+            "127.0.0.1",
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+        snapcastControlClient.initialize()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            snapcastControlClient.notifications
+                // If it wasn't for this catch, the collection would fail...
+                .catch { exception ->
+                    println("caught: $exception")
+                }
+                .collect {
+                    println("collected: $it")
+                }
+        }
+
+        snapcastControlClient.sendGetStatus()
+
+        val clientJob = backgroundScope.launch(Dispatchers.IO) {
+            SnapclientProcess(appContext, radioRepository).start()
+        }
+
+        serverJob.cancelAndJoin()
+        clientJob.cancelAndJoin()
+        assert(serverJob.isCancelled)
+
+        // ...therefore we count this test being able to finish as "passing"
     }
 }

--- a/app/src/main/java/tech/capullo/radio/snapcast/SnapcastControlClient.kt
+++ b/app/src/main/java/tech/capullo/radio/snapcast/SnapcastControlClient.kt
@@ -1,5 +1,6 @@
 package tech.capullo.radio.snapcast
 
+import android.util.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
@@ -9,19 +10,22 @@ import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.http.HttpMethod
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import io.ktor.websocket.Frame
+import io.ktor.websocket.close
 import io.ktor.websocket.readText
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
-import kotlinx.serialization.Serializable
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.util.concurrent.TimeUnit
 
-class SnapcastControlClient(private val snapserverHostAddress: String) {
+class SnapcastControlClient(
+    private val snapserverHostAddress: String,
+    private val tag: Int = 1,
+    private val websocketPort: Int = 1780,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
     val client = HttpClient(OkHttp) {
         engine {
             config {
@@ -34,57 +38,58 @@ class SnapcastControlClient(private val snapserverHostAddress: String) {
         }
     }
 
-    private val _serverStatus = MutableSharedFlow<SnapcastServerStatus>()
-    val serverStatus: SharedFlow<SnapcastServerStatus> = _serverStatus
-
-    var receiveJob: Job? = null
     private var session: DefaultClientWebSocketSession? = null
 
-    suspend fun initWebsocket() = coroutineScope {
-        val session = client.webSocketSession(
+    private var requestIdCounter: Int = 1
+
+    suspend fun initialize() = withContext(ioDispatcher) {
+        session = client.webSocketSession(
             method = HttpMethod.Get,
             host = snapserverHostAddress,
-            port = DEFAULT_WS_PORT,
+            port = websocketPort,
             path = "/jsonrpc",
         )
-
-        receiveJob = launch {
-            try {
-                while (true) {
-                    ensureActive()
-                    val frame = session.incoming.receive() as? Frame.Text
-                    println("Received frame: ${frame?.readText()}")
-
-                    val jsonString = frame?.readText()
-                    jsonString?.let {
-                        try {
-                            val response = Json.decodeFromString<SnapcastServerStatus>(jsonString)
-                            println(response)
-                            _serverStatus.emit(response)
-                            println("emmitting server status")
-                        } catch (e: Exception) {
-                            println("Error decoding response: $e")
-                        }
-                    }
-                }
-            } catch (e: CancellationException) {
-                println("Websocket receive job cancelled")
-            } catch (e: Exception) {
-                println("Error receiving frame: $e")
-            }
-        }
-
-        println("sending frame")
-        val getStatus = SnapcastGetStatusRequest(1, "2.0", "Server.GetStatus")
-        session.sendSerialized(getStatus)
     }
 
-    @Serializable
-    data class SnapcastGetStatusRequest(val id: Int, val jsonrpc: String, val method: String)
+    val notifications: Flow<SnapcastJSONRPCResponse?> = flow {
+        while (true) {
+            val frame = withContext(ioDispatcher) {
+                session?.incoming?.receive() as? Frame.Text
+            }
+            frame?.readText()?.also { jsonString ->
+                val response = try {
+                    Json.decodeFromString(SnapcastJSONRPCResponseSerializer, jsonString)
+                } catch (e: Exception) {
+                    Log.d(TAG, "Error decoding response: $e")
+                    null
+                }
+                emit(response)
+            }
+        }
+    }
+
+    suspend fun sendGetStatus() {
+        val getStatusRequest = ServerGetStatusRequest(id = requestIdCounter++)
+        session?.sendSerialized(getStatusRequest)
+    }
+
+    suspend fun sendSetVolume(clientId: String, muted: Boolean, percent: Int) {
+        val volume = Volume(
+            muted = muted,
+            percent = percent,
+        )
+        val setVolume = ClientSetVolumeRequest(
+            id = requestIdCounter++,
+            params = VolumeParams(
+                clientId = clientId,
+                volume = volume,
+            ),
+        )
+
+        session?.sendSerialized(setVolume)
+    }
 
     companion object {
-        private const val TAG = "SnapcastControlClient"
-        private const val DEFAULT_PORT = 1705
-        private const val DEFAULT_WS_PORT = 1780
+        private val TAG = SnapcastControlClient::class.simpleName
     }
 }

--- a/app/src/main/java/tech/capullo/radio/snapcast/SnapcastJSONRPC.kt
+++ b/app/src/main/java/tech/capullo/radio/snapcast/SnapcastJSONRPC.kt
@@ -1,12 +1,36 @@
 package tech.capullo.radio.snapcast
 
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+// Requests
+// https://github.com/badaix/snapcast/blob/develop/doc/json_rpc_api/control.md#requests-1
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class ServerGetStatusRequest(
+    val id: Int,
+    @EncodeDefault
+    val jsonrpc: String = "2.0",
+    @EncodeDefault
+    val method: String = "Server.GetStatus",
+)
 
 @Serializable
-data class SnapcastServerStatus(val id: Int, val jsonrpc: String, val result: Result)
+data class ServerGetStatusResponse(
+    override val id: Int,
+    override val jsonrpc: String,
+    val result: ServerStatusResult,
+) : RequestResponse()
 
 @Serializable
-data class Result(val server: ServerInfo)
+data class ServerStatusResult(val server: ServerInfo)
 
 @Serializable
 data class ServerInfo(val groups: List<Group>, val server: Server, val streams: List<Stream>)
@@ -17,7 +41,8 @@ data class Group(
     val id: String,
     val muted: Boolean,
     val name: String,
-    val stream_id: String,
+    @SerialName("stream_id")
+    val streamId: String,
 )
 
 @Serializable
@@ -86,10 +111,108 @@ data class StreamUri(
 
 @Serializable
 data class StreamQuery(
-    val chunk_ms: String,
+    @SerialName("chunk_ms")
+    val chunkMs: String,
     val codec: String,
-    val dryout_ms: String,
+    @SerialName("dryout_ms")
+    val dryoutMs: String,
     val mode: String,
     val name: String,
     val sampleformat: String,
 )
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class ClientSetVolumeRequest(
+    val id: Int,
+    @EncodeDefault
+    val jsonrpc: String = "2.0",
+    @EncodeDefault
+    val method: String = "Client.SetVolume",
+    val params: VolumeParams,
+)
+
+@Serializable
+data class VolumeParams(
+    @SerialName("id")
+    val clientId: String,
+    val volume: Volume,
+)
+
+// Notifications
+// https://github.com/badaix/snapcast/blob/develop/doc/json_rpc_api/control.md#notifications
+@Serializable
+abstract class Notification : SnapcastJSONRPCResponse() {
+    abstract override val jsonrpc: String
+    abstract val method: String
+}
+
+@Serializable
+data class GenericNotification(
+    override val jsonrpc: String,
+    override val method: String,
+    val params: JsonObject,
+) : Notification()
+
+@Serializable
+data class ClientOnVolumeChanged(
+    override val jsonrpc: String,
+    override val method: String,
+    val params: VolumeParams,
+) : Notification()
+
+@Serializable
+data class ServerOnUpdate(
+    override val jsonrpc: String,
+    override val method: String,
+    val params: ServerStatusResult,
+) : Notification()
+
+object NotificationSerializer : JsonContentPolymorphicSerializer<Notification>(
+    Notification::class,
+) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Notification> {
+        val method = element.jsonObject["method"]
+        return when (method.toString()) {
+            "\"Server.OnUpdate\"" -> ServerOnUpdate.serializer()
+            "\"Client.OnVolumeChanged\"" -> ClientOnVolumeChanged.serializer()
+            else -> GenericNotification.serializer()
+        }
+    }
+}
+
+// Custom serializers for polymorphism
+@Serializable
+abstract class RequestResponse : SnapcastJSONRPCResponse() {
+    abstract val id: Int
+    abstract override val jsonrpc: String
+}
+
+object RequestResponseSerializer : JsonContentPolymorphicSerializer<RequestResponse>(
+    RequestResponse::class,
+) {
+    override fun selectDeserializer(
+        element: JsonElement,
+    ): DeserializationStrategy<RequestResponse> {
+        // TODO: add serializers for all kinds of responses
+        return ServerGetStatusResponse.serializer()
+    }
+}
+
+@Serializable
+abstract class SnapcastJSONRPCResponse {
+    abstract val jsonrpc: String
+}
+
+object SnapcastJSONRPCResponseSerializer :
+    JsonContentPolymorphicSerializer<SnapcastJSONRPCResponse>(
+        SnapcastJSONRPCResponse::class,
+    ) {
+    override fun selectDeserializer(
+        element: JsonElement,
+    ): DeserializationStrategy<SnapcastJSONRPCResponse> = if ("method" in element.jsonObject) {
+        NotificationSerializer
+    } else {
+        RequestResponseSerializer
+    }
+}

--- a/app/src/test/java/tech/capullo/radio/SnapcastControlClient.kt
+++ b/app/src/test/java/tech/capullo/radio/SnapcastControlClient.kt
@@ -1,0 +1,246 @@
+package tech.capullo.radio
+
+import android.R
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import tech.capullo.radio.snapcast.ClientOnVolumeChanged
+import tech.capullo.radio.snapcast.NotificationSerializer
+import tech.capullo.radio.snapcast.ServerGetStatusResponse
+import tech.capullo.radio.snapcast.ServerOnUpdate
+import tech.capullo.radio.snapcast.SnapcastJSONRPCResponse
+import tech.capullo.radio.snapcast.SnapcastJSONRPCResponseSerializer
+
+class SnapcastControlClient {
+
+    @Test
+    fun serverGetStatusResponseDeserializeTest() {
+        val serverGetStatusString = """
+            {
+              "id": 2,
+              "jsonrpc": "2.0",
+              "result": {
+                "server": {
+                  "groups": [
+                    {
+                      "clients": [
+                        {
+                          "config": {
+                            "instance": 1,
+                            "latency": 0,
+                            "name": "",
+                            "volume": {
+                              "muted": false,
+                              "percent": 100
+                            }
+                          },
+                          "connected": true,
+                          "host": {
+                            "arch": "x86_64",
+                            "ip": "::ffff:127.0.0.1",
+                            "mac": "00:00:00:00:00:00",
+                            "name": "sdk_gphone64_x86_64",
+                            "os": "Android 16"
+                          },
+                          "id": "031a7306-6a7d-4a52-ab7d-3c08051b1d84",
+                          "lastSeen": {
+                            "sec": 1762503830,
+                            "usec": 240402
+                          },
+                          "snapclient": {
+                            "name": "Snapclient",
+                            "protocolVersion": 2,
+                            "version": "0.34.0"
+                          }
+                        }
+                      ],
+                      "id": "5447d658-940b-a745-a122-b0c213b9b400",
+                      "muted": false,
+                      "name": "",
+                      "stream_id": "RadioCapullo"
+                    }
+                  ],
+                  "server": {
+                    "host": {
+                      "arch": "x86_64",
+                      "ip": "",
+                      "mac": "",
+                      "name": "sdk_gphone64_x86_64",
+                      "os": "Android 16"
+                    },
+                    "snapserver": {
+                      "controlProtocolVersion": 1,
+                      "name": "Snapserver",
+                      "protocolVersion": 1,
+                      "version": "0.34.0"
+                    }
+                  },
+                  "streams": [
+                    {
+                      "id": "RadioCapullo",
+                      "properties": {
+                        "canControl": false,
+                        "canGoNext": false,
+                        "canGoPrevious": false,
+                        "canPause": false,
+                        "canPlay": false,
+                        "canSeek": false
+                      },
+                      "status": "idle",
+                      "uri": {
+                        "fragment": "",
+                        "host": "",
+                        "path": "/data/user/0/tech.capullo.radio/cache/filifo",
+                        "query": {
+                          "chunk_ms": "20",
+                          "codec": "flac",
+                          "dryout_ms": "2000",
+                          "mode": "read",
+                          "name": "RadioCapullo",
+                          "sampleformat": "44100:16:2"
+                        },
+                        "raw": "pipe:///data/user/0/tech.capullo.radio/cache/filifo?chunk_ms=20&codec=flac&dryout_ms=2000&mode=read&name=RadioCapullo&sampleformat=44100%3A16%3A2",
+                        "scheme": "pipe"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+        """.trimIndent()
+        val response =
+            Json.decodeFromString(SnapcastJSONRPCResponseSerializer, serverGetStatusString)
+
+        assert(response is ServerGetStatusResponse)
+    }
+
+    @Test
+    fun clientOnVolumeChangedDeserializeTest() {
+        val clientId = "82c9349e-da57-401a-aefa-2eb68b358ef3"
+        val muted = true
+        val percent = 20
+        val onVolumeChangedString = """
+        {
+          "jsonrpc": "2.0",
+          "method": "Client.OnVolumeChanged",
+          "params": {
+            "id": "$clientId",
+            "volume": {
+              "muted": $muted,
+              "percent": $percent
+            }
+          }
+        }
+    """
+
+        val response =
+            Json.decodeFromString(SnapcastJSONRPCResponseSerializer, onVolumeChangedString)
+
+        assert(response is ClientOnVolumeChanged)
+        (response as ClientOnVolumeChanged).let {
+            assert(it.params.clientId == clientId)
+            assert(it.params.volume.muted == muted)
+            assert(it.params.volume.percent == percent)
+        }
+    }
+
+    @Test
+    fun serverOnUpdateDeserializeTest() {
+        val onUpdateString = """
+            {
+              "jsonrpc": "2.0",
+              "method": "Server.OnUpdate",
+              "params": {
+                "server": {
+                  "groups": [
+                    {
+                      "clients": [
+                        {
+                          "config": {
+                            "instance": 1,
+                            "latency": 0,
+                            "name": "",
+                            "volume": {
+                              "muted": false,
+                              "percent": 100
+                            }
+                          },
+                          "connected": true,
+                          "host": {
+                            "arch": "x86_64",
+                            "ip": "::ffff:127.0.0.1",
+                            "mac": "00:00:00:00:00:00",
+                            "name": "sdk_gphone64_x86_64",
+                            "os": "Android 16"
+                          },
+                          "id": "e694ba4d-3b37-4303-ab0c-c0aa41165385",
+                          "lastSeen": {
+                            "sec": 1762426399,
+                            "usec": 509162
+                          },
+                          "snapclient": {
+                            "name": "Snapclient",
+                            "protocolVersion": 2,
+                            "version": "0.34.0"
+                          }
+                        }
+                      ],
+                      "id": "3f80e383-6603-682c-ebc7-c8b1d4314640",
+                      "muted": false,
+                      "name": "",
+                      "stream_id": "RadioCapullo"
+                    }
+                  ],
+                  "server": {
+                    "host": {
+                      "arch": "x86_64",
+                      "ip": "",
+                      "mac": "",
+                      "name": "sdk_gphone64_x86_64",
+                      "os": "Android 16"
+                    },
+                    "snapserver": {
+                      "controlProtocolVersion": 1,
+                      "name": "Snapserver",
+                      "protocolVersion": 1,
+                      "version": "0.34.0"
+                    }
+                  },
+                  "streams": [
+                    {
+                      "id": "RadioCapullo",
+                      "properties": {
+                        "canControl": false,
+                        "canGoNext": false,
+                        "canGoPrevious": false,
+                        "canPause": false,
+                        "canPlay": false,
+                        "canSeek": false
+                      },
+                      "status": "idle",
+                      "uri": {
+                        "fragment": "",
+                        "host": "",
+                        "path": "/data/user/0/tech.capullo.radio/cache/filifo",
+                        "query": {
+                          "chunk_ms": "20",
+                          "codec": "flac",
+                          "dryout_ms": "2000",
+                          "mode": "read",
+                          "name": "RadioCapullo",
+                          "sampleformat": "44100:16:2"
+                        },
+                        "raw": "pipe:///data/user/0/tech.capullo.radio/cache/filifo?chunk_ms=20&codec=flac&dryout_ms=2000&mode=read&name=RadioCapullo&sampleformat=44100%3A16%3A2",
+                        "scheme": "pipe"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+        """.trimIndent()
+
+        val response =
+            Json.decodeFromString(SnapcastJSONRPCResponseSerializer, onUpdateString)
+        assert(response is ServerOnUpdate)
+    }
+}


### PR DESCRIPTION
- Data classes to deserialize both notifications and request responses coming from servers
  - Thus far, only for `Server.GetStatus`, `Server.OnUpdate`, and `Client.OnVolumeChange`
- Unit and integration testing for both polymorphic deserializer and flow consumption