### PR TITLE
feat: CI/CD preview/release

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-      - experimental/*
   pull_request:
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - '**'
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
@@ -9,35 +11,42 @@ permissions:
   contents: write
 
 jobs:
+  build:
+    uses: ./.github/workflows/Build.yml
   release:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Setup Java
-        uses: actions/setup-java@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Build APK
-        env:
-          GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew :app:assembleDebug
+          name: radio_capullo-${{ github.sha }}
+          path: ./artifacts
       - name: Create Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag=$(git describe --tags --abbrev=0)
-          gh release create "$tag" \
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            tag="${{ github.ref_name }}"
+            gh release create "$tag" \
               --generate-notes
-      - name: Upload Release Asset
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          tag=$(git describe --tags --abbrev=0)
-          gh release upload "$tag" "./app/build/outputs/apk/debug/app-debug.apk#radio_capullo-$tag.apk"
+          else
+            commit_hash=$(git rev-parse --short HEAD)
+            tag="preview"
+            
+            gh release delete "$tag" --yes || true
+            git tag -d "$tag" || true
+            git push origin :refs/tags/preview || true
+
+            gh release create "$tag" \
+              --target "${{ github.ref_name }}" \
+              --prerelease \
+              --notes "Preview - $commit_hash"
+          fi
+
+          apk_file=$(find ./artifacts -name "*.apk" | head -1)
+          gh release upload "$tag" "$apk_file#radio_capullo-$tag.apk"


### PR DESCRIPTION
- Release workflow to run on all branches and tags
- Create `preview` release when on all pushes, delete previous `preview` tags and release so we maintain only one instance
- Create normal release when pushing tags